### PR TITLE
[FIX] suppression valeur par défaut dans interface pour ESDBautocommit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 16/02/22
+**Version 1.0.2**
+- BUGFIX : La fonction ESDBautocommit ne respectait pas ce qui était définit dans l'interface. La valeur par défaut "false" dans ESDBaccessInterface a été supprimée
+- Remplacement de "self::" par "$this->" dans la classe ESDBaccess car utilisée par des classes non statiques
+
 ## 14/02/22
 **Version 1.0.1**
 - Ajout des méthodes "throw new" manquantes qui ne jetaient pas d'exceptions

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "vanhaex/esdbaccess",
     "description": "Une interface de connexion à la base de données qui utilise le moteur MySQLi",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "type": "package",
     "license": "MIT",
     "minimum-stability": "stable",

--- a/src/ESDBaccess.php
+++ b/src/ESDBaccess.php
@@ -291,7 +291,7 @@ class ESDBaccess implements ESDBaccessInterface
      */
     public function ESDBcommit(): bool
     {
-        if (self::ESDBautocommit($this->isActive) == false){
+        if ($this->ESDBautocommit($this->isActive) == false){
             return $this->sql->commit();
         }
         else {
@@ -304,7 +304,7 @@ class ESDBaccess implements ESDBaccessInterface
      */
     public function ESDBrollback(): bool
     {
-        if (self::ESDBautocommit($this->isActive) == false){
+        if ($this->ESDBautocommit($this->isActive) == false){
             return $this->sql->rollback();
         }
         else {

--- a/src/ESDBaccessInterface.php
+++ b/src/ESDBaccessInterface.php
@@ -82,7 +82,7 @@ interface ESDBaccessInterface
      * @param false $isActive
      * @return bool
      */
-    public function ESDBautocommit(bool $isActive = false) : bool;
+    public function ESDBautocommit(bool $isActive) : bool;
 
     /**
      * Mode transactionnel, permet de valider la requête. Ne fonctionne que si le mode autocommit est à false


### PR DESCRIPTION
## 16/02/22
**Version 1.0.2**
- BUGFIX : La fonction ESDBautocommit ne respectait pas ce qui était définit dans l'interface. La valeur par défaut "false" dans ESDBaccessInterface a été supprimée
- Remplacement de "self::" par "$this->" dans la classe ESDBaccess car utilisée par des classes non statiques
